### PR TITLE
Add backwards-compatible universal module definition wrapper

### DIFF
--- a/lib/micro-location.js
+++ b/lib/micro-location.js
@@ -90,4 +90,20 @@ Location.parse = function (string) {
 	return ret;
 };
 
-this.Location = Location;
+(function (root, factory) {
+	if (typeof module === "object" && module.exports) {
+		module.exports = { 
+			Location: factory()
+		};
+	} else if (typeof define === 'function' && define.amd) {
+		define([], function () {
+			return {
+				Location: factory()
+			}
+		});
+	} else {
+		root.Location = factory();
+	}
+}(this, function () {
+	return Location;
+}));

--- a/test/amd-test.html
+++ b/test/amd-test.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>micro-location AMD Test</title>
+
+	<style>
+	.error {
+		color: red;
+	}
+	</style>
+</head>
+<body>
+	<div id="logger"></div>
+
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.20/require.min.js"></script>
+	<script>
+	(function () {
+		var logger = document.getElementById('logger');
+		function log (msg, type) {
+			var el = document.createElement('div');
+			type = type || 'log';
+			el.className = type ;
+			el.innerText = msg;
+			logger.appendChild(el);
+
+			console[type](msg);
+		};
+
+		function error (msg) {
+			log(msg, 'error');
+		}
+
+		require(['../lib/micro-location'], function (microLocation) {
+			try {
+				var loc = microLocation.Location.parse(location.href);
+				log('AMD exported properly');
+			} catch (ex) {
+				error('AMD failed to load properly');
+			}
+		});
+	})();
+	</script>
+</body>
+</html>


### PR DESCRIPTION
We are using this module in a library which is then used in other libraries which are then used in other libraries.  We export our libraries in CJS, AMD, and global formats and it is simply too much to shim this in all of our AMD builds as it requires the users of our libraries to do the same. This change will not break existing implementations and will allow AMD loaders to load this more elegantly and keep from polluting the global namespace.
